### PR TITLE
Fix the docker build failing

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -46,6 +46,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,30 @@
-FROM rust:1.66-alpine as builder
-WORKDIR /usr/src/shadow-tls
-RUN apk add --no-cache musl-dev libressl-dev
+# Add another layer just to fetch Cargo on the build platform.
+# This is to work around this issue with QEMU on ARMv7: https://github.com/docker/buildx/issues/395
+# More details: https://gitlab.com/qemu-project/qemu/-/issues/263 and https://github.com/rust-lang/cargo/issues/8719
+FROM --platform=$BUILDPLATFORM rust:1.66.1-slim-buster as sources
 
-COPY . .
-RUN RUSTFLAGS="" cargo build --bin shadow-tls --release
+WORKDIR /usr/src/shadow-tls
+RUN cargo init
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
+RUN mkdir -p ./.cargo \
+  && cargo vendor > ./.cargo/config
+
+FROM rust:1.66.1-slim-buster as builder
+
+WORKDIR /usr/src/shadow-tls
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+   build-essential \
+   libssl-dev;
+
+
+COPY ./ ./
+COPY --from=sources /usr/src/shadow-tls/.cargo ./.cargo
+COPY --from=sources /usr/src/shadow-tls/vendor ./vendor
+
+RUN RUSTFLAGS="" cargo build --bin shadow-tls --release --offline
 
 FROM alpine:latest
 


### PR DESCRIPTION
Removes the ARMv6 docker build platform from the action since no official rust image supports it.

FIxes the rust Cargo error encountered when the docker build is run on ARMv7 emulated by QEMU by adding a workaround. https://gitlab.com/qemu-project/qemu/-/issues/263 for more details on the issue.
