### PR TITLE
Allow content write permission for build action

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   build-cross:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       RUST_BACKTRACE: full
     strategy:
@@ -45,6 +47,8 @@ jobs:
           prerelease: ${{ contains(github.ref, '-') }}
   build-unix:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       RUST_BACKTRACE: full
     strategy:


### PR DESCRIPTION
This will fix the [Build Releases](https://github.com/0xf00f00/shadow-tls/actions/workflows/build-release.yml) workflow failing when creating the release on GitHub.